### PR TITLE
Don't make h5 header all caps

### DIFF
--- a/src/mkdocstrings_handlers/zig/templates/material/style.css
+++ b/src/mkdocstrings_handlers/zig/templates/material/style.css
@@ -42,3 +42,8 @@ td p {
   margin: 0;
   padding: 0;
 }
+
+.md-typeset h5 {
+  color: var(--md-default-fg-color);
+  text-transform: none;
+}


### PR DESCRIPTION
Related mkdocs issue: https://github.com/squidfunk/mkdocs-material/issues/1522